### PR TITLE
ci: add a Linux aarch64 build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -37,6 +37,23 @@ libretro-build-linux-x64:
     - .libretro-rust-linux-x64-default
     - .core-defs
 
+# Linux aarch64
+# Cross-compiled from the same image as the x64 job, the way the image already
+# cross-compiles the Apple and Android arm64 targets. There is no
+# rust-linux-aarch64.yml template yet (libretro/libretro-super#2030) and the
+# rust image is amd64-only, so the target and its linker are added here.
+libretro-build-linux-aarch64:
+  extends:
+    - .libretro-rust-linux-x64
+    - .core-defs
+  variables:
+    TARGET_ARCH: aarch64-unknown-linux-gnu
+    STRIP: aarch64-linux-gnu-strip
+    CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
+  before_script:
+    - apt-get update -qy && apt-get install -yq gcc-aarch64-linux-gnu
+    - rustup target add aarch64-unknown-linux-gnu
+
 # MacOS 64-bit
 libretro-build-osx-x64:
   extends:


### PR DESCRIPTION
Adds a `libretro-build-linux-aarch64` job so the core lands in `nightly/linux/aarch64/` on the buildbot. There is currently no Linux aarch64 build of holani at all, while there are 160 other cores there.

### Why it is not a one-liner

Unlike the CMake/Makefile cores, there is no `rust-linux-aarch64.yml` template in ci-templates — only `rust-linux-x64.yml` — and the `libretro-build-rust` image is `FROM libretro-build-amd64-ubuntu`, so there is no native aarch64 image to point at either. I raised the template gap as libretro/libretro-super#2030.

Rather than wait on infrastructure, this job cross-compiles from the same image the x64 job already uses, in exactly the style that image already uses for its other arm64 targets (it sets `CARGO_TARGET_AARCH64_APPLE_DARWIN_LINKER`, `CARGO_TARGET_AARCH64_APPLE_IOS_LINKER` and so on):

```yaml
  variables:
    TARGET_ARCH: aarch64-unknown-linux-gnu
    STRIP: aarch64-linux-gnu-strip
    CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
  before_script:
    - apt-get update -qy && apt-get install -yq gcc-aarch64-linux-gnu
    - rustup target add aarch64-unknown-linux-gnu
```

`STRIP` is overridden because the template's default `strip` is the host binutils; the same override already exists in `rust-webos.yml`. The `.libretro-rust-linux-x64` base class is extended directly rather than `-default`, since that is what pins `TARGET_ARCH` to x86_64.

If a `rust-linux-aarch64.yml` template ever appears, this whole job collapses into an `extends:` line.

### Tested on real aarch64 hardware

Built and run natively on an aarch64 Linux machine (Snapdragon 7c / SC7180, postmarketOS), Rust 1.97.1, target `aarch64-unknown-linux-gnu`:

* **the core needs no source changes** — `cargo build --release --target aarch64-unknown-linux-gnu` is clean, including the bindgen step in `libretro-rs-ffi`
* `libholani.so`, ELF 64-bit LSB shared object, ARM aarch64, 906 KB
* in RetroArch: *Double Dragon* (USA, Europe) boots and plays — difficulty menu, then in-game with correct colours at 160x102, XRGB8888
* 3000 frames, exit code 0, no crash

One honest performance note, unrelated to this PR: measured with a minimal libretro host (no vsync), the core ran **57.5 fps against the 75 fps it asks for, so about 77% of realtime** on that SoC. It is playable but not full speed there. That is the cost of the accuracy-oriented design, not something the build job affects — I mention it only so nobody is surprised by an aarch64 nightly that runs slow on weaker ARM boards.

**What I could not test:** I built natively on aarch64 hardware, whereas this job cross-compiles from x86_64. The bindgen step is the part that differs, and the existing `android-arm64-v8a` job already cross-compiles this same crate for an arm64 target from that image, so the path is exercised — but I cannot run GitLab pipelines from a GitHub PR, so the job itself has not been executed by CI.
